### PR TITLE
Added optional meta key to the success JSON

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,8 @@ success::
  >>> jsend.success({'key': 'value'})
  {'status': 'success', 'data': {'key': 'value'}}
 
+ >>> jsend.success(data={'key': 'value'}, meta={'meta_key': 'meta_val'})
+ {'status': 'success', 'data': {'key': 'value'}, 'meta': {'meta_key', 'meta_val'}}
 
 fail::
 

--- a/jsend/jsend.py
+++ b/jsend/jsend.py
@@ -2,21 +2,29 @@ __author__ = 'zirony'
 
 import json
 
+
 # Support Python 2/3 unicode
 try:
     strtype = unicode
 except:
     strtype = bytes
 
+
 class DictEx(dict):
     def stringify(self):
         return json.dumps(self)
 
 
-def success(data={}):
-    if not isinstance(data, dict):
+def success(data={}, meta=None):
+    ret = {}
+    if not isinstance(data, dict) or (meta and not isinstance(meta, dict)):
         raise ValueError('data must be the dict type')
-    return DictEx({'status': 'success', 'data': data})
+    ret['status'] = 'success'
+    ret['data'] = data
+    if meta:
+        ret['meta']=meta
+
+    return DictEx(ret)
 
 
 def fail(data={}):

--- a/tests/test_tool_jsend.py
+++ b/tests/test_tool_jsend.py
@@ -10,9 +10,21 @@ class TestJsend(TestCase):
         self.assertTrue(jsend.is_success(ret))
         self.assertEqual(ret['data']['key'], 'value')
 
+    def test_success_with_meta(self):
+        ret = jsend.success(data={'key': 'value'}, meta={'meta_key': 'meta_value'})
+        self.assertTrue(ret['meta']['meta_key'], 'meta_value')
+        self.assertTrue(ret['data']['key'], 'value')
+
     def test_success_data_must_be_dict(self):
         try:
             jsend.success(data=1)
+        except ValueError:
+            return
+        self.fail()
+
+    def test_success_meta_must_be_dict(self):
+        try:
+            jsend.success(data={'key', 'value'}, meta=1)
         except ValueError:
             return
         self.fail()


### PR DESCRIPTION
I loved the simplicity of the approach, but felt the need to split the data out from any meta data that may need returning such as next page data or record counts.

I have added the meta key to the success function and updated the tests and docs.

Feel free to include if you see it as a worthy addition with out breaking the concept of keeping simple.