### PR TITLE
The `stringify` method now accepts an `ensure_ascii` parameter.  

### DIFF
--- a/jsend/jsend.py
+++ b/jsend/jsend.py
@@ -8,9 +8,10 @@ try:
 except:
     strtype = bytes
 
+
 class DictEx(dict):
-    def stringify(self):
-        return json.dumps(self)
+    def stringify(self, ensure_ascii=True):
+        return json.dumps(self, ensure_ascii=ensure_ascii)
 
 
 def success(data={}):


### PR DESCRIPTION
The `stringify` method now accepts an `ensure_ascii` parameter.  Setting it to `False` prevents encoding Chinese characters.
